### PR TITLE
許可しない文字を受け付けない様にしました

### DIFF
--- a/nopaste.go
+++ b/nopaste.go
@@ -46,8 +46,8 @@ func (np *Nopaste) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 
 	if p := strings.TrimPrefix(upath, np.config.Root+"/"); len(p) < len(upath) {
-		req.URL.Path = p
-		if strings.IndexFunc(upath, isAlnum) != -1 {
+		if strings.IndexFunc(p, isAlnum) != -1 {
+			req.URL.Path = p
 			np.dataHandler(w, req)
 			return
 		}

--- a/nopaste.go
+++ b/nopaste.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"path"
 	"strings"
 )
 
@@ -80,7 +81,7 @@ func (np *Nopaste) saveContent(w http.ResponseWriter, req *http.Request) {
 		serverError(w)
 		return
 	}
-	http.Redirect(w, req, np.config.Root+"/"+id, http.StatusFound)
+	http.Redirect(w, req, path.Join(np.config.Root, id), http.StatusFound)
 }
 
 func (np *Nopaste) dataHandler(w http.ResponseWriter, req *http.Request) {

--- a/nopaste.go
+++ b/nopaste.go
@@ -32,6 +32,10 @@ func New(config *Config) *Nopaste {
 	}
 }
 
+func isAlnum(r rune) bool {
+	return ('a' <= r && r <= 'z') || ('A' <= r && r <= 'Z') || ('0' <= r && r <= '9')
+}
+
 func (np *Nopaste) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	upath := req.URL.Path
 
@@ -42,8 +46,10 @@ func (np *Nopaste) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	if p := strings.TrimPrefix(upath, np.config.Root+"/"); len(p) < len(upath) {
 		req.URL.Path = p
-		np.dataHandler(w, req)
-		return
+		if strings.IndexFunc(upath, isAlnum) != -1 {
+			np.dataHandler(w, req)
+			return
+		}
 	}
 
 	http.NotFound(w, req)

--- a/nopaste_test.go
+++ b/nopaste_test.go
@@ -1,0 +1,77 @@
+package nopaste
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSimple(t *testing.T) {
+	dir, err := ioutil.TempDir("", "nopaste")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	nopaste := New(&Config{
+		Root:    "",
+		DataDir: dir,
+	})
+	ts := httptest.NewServer(nopaste)
+	defer ts.Close()
+
+	client := ts.Client()
+
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	want := "hello"
+	resp, err := client.PostForm(ts.URL, url.Values{
+		"text": []string{want},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	loc := strings.TrimLeft(resp.Header.Get("Location"), "/")
+	b, err := ioutil.ReadFile(filepath.Join(dir, loc) + ".txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := string(b)
+	if got != want {
+		t.Fatalf("want %q but got %q", want, got)
+	}
+}
+
+func TestWithBackslash(t *testing.T) {
+	dir, err := ioutil.TempDir("", "nopaste")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	nopaste := New(&Config{
+		Root:    "",
+		DataDir: dir,
+	})
+	ts := httptest.NewServer(nopaste)
+	defer ts.Close()
+
+	client := ts.Client()
+
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	_, err = client.Get(`/..\..\..\evil`)
+	if err == nil {
+		t.Fatalf("backslash should not be accepted")
+	}
+}


### PR DESCRIPTION
Windows だと `/..%5c..%5c` の様なアクセスでローカルのファイルが見えてしまう(とは言っても .txt のみ)ので受け付ける文字を制限しましたー。